### PR TITLE
EPMRPP-108013 || Update log level validation constraints

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import java.time.Instant;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -62,7 +64,8 @@ public class SaveLogRQ {
   private String message;
 
   @JsonProperty(value = "level")
-  @Schema(allowableValues = "error, warn, info, debug, trace, fatal, unknown")
+  @Size(min = 3, max = 16)
+  @Pattern(regexp = "^[A-Za-z0-9 ]+$")
   private String level;
 
   @JsonProperty(value = "file")

--- a/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
@@ -63,7 +63,6 @@ public class SaveLogRQ {
   @JsonProperty(value = "message")
   private String message;
 
-  @NotNull
   @JsonProperty(value = "level")
   @Size(min = 3, max = 16)
   @Pattern(regexp = "^[A-Za-z0-9 ]+$")

--- a/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
+++ b/src/main/java/com/epam/ta/reportportal/ws/reporting/SaveLogRQ.java
@@ -63,6 +63,7 @@ public class SaveLogRQ {
   @JsonProperty(value = "message")
   private String message;
 
+  @NotNull
   @JsonProperty(value = "level")
   @Size(min = 3, max = 16)
   @Pattern(regexp = "^[A-Za-z0-9 ]+$")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for log-level in save-log requests: values must be 3–16 characters, non-null, and contain only letters, numbers, or spaces. Invalid inputs now produce clear validation errors, improving consistency and reliability of submitted logs and reducing malformed log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->